### PR TITLE
TRUS-2835: Do not overwrite entity start date for personal rep sent from front end.

### DIFF
--- a/app/uk/gov/hmrc/estates/transformers/variations/AddAmendPersonalRepTransform.scala
+++ b/app/uk/gov/hmrc/estates/transformers/variations/AddAmendPersonalRepTransform.scala
@@ -21,19 +21,12 @@ import play.api.libs.json._
 trait AddAmendPersonalRepTransform {
   def setPersonalRep(input: JsValue, newPersonalRepDetails: JsValue): JsResult[JsValue] = {
     val personalRepPath = (__ \ 'details \ 'estate \ 'entities \ 'personalRepresentative)
-    val entityStartPath = personalRepPath \ 'entityStart
 
-    val entityStartPick = entityStartPath.json.pick
-    input.transform(entityStartPick) match {
-      case JsSuccess(entityStart, _) =>
-        input.transform(
-          personalRepPath.json.prune andThen
-            (__).json.update(personalRepPath.json.put(newPersonalRepDetails)) andThen
-            (__).json.update(entityStartPath.json.put(entityStart)) andThen
-            (personalRepPath \ 'lineNo).json.prune andThen
-            (personalRepPath \ 'bpMatchStatus).json.prune
-        )
-      case e: JsError => e
-    }
+    input.transform(
+      personalRepPath.json.prune andThen
+        (__).json.update(personalRepPath.json.put(newPersonalRepDetails)) andThen
+        (personalRepPath \ 'lineNo).json.prune andThen
+        (personalRepPath \ 'bpMatchStatus).json.prune
+    )
   }
 }

--- a/it/transforms/variations/AmendPersonalRepSpec.scala
+++ b/it/transforms/variations/AmendPersonalRepSpec.scala
@@ -84,7 +84,7 @@ class AmendPersonalRepSpec extends AsyncFreeSpec with MustMatchers with MockitoS
             Some("TF1 5DR"),
             "GB"
           ))),
-        entityStart = LocalDate.of(1965, 2, 10),
+        entityStart = LocalDate.of(2007, 4, 13),
         entityEnd = None
       )
 

--- a/test/resources/it/estates-integration-get-after-amend-personal-rep.json
+++ b/test/resources/it/estates-integration-get-after-amend-personal-rep.json
@@ -49,7 +49,7 @@
               }
             },
             "phoneNumber": "newPhone",
-            "entityStart": "2017-02-28",
+            "entityStart": "2007-04-13",
             "name": {
               "firstName": "newFirstName",
               "middleName": "newMiddleName",

--- a/test/resources/transformed/variations/estates-personal-rep-transform-after-ind.json
+++ b/test/resources/transformed/variations/estates-personal-rep-transform-after-ind.json
@@ -14,7 +14,7 @@
           "identification":{
             "nino":"newNino"
           },
-          "entityStart":"1998-02-12"
+          "entityStart":"2012-03-14"
         }
       }
     }

--- a/test/resources/transformed/variations/estates-personal-rep-transform-after-org.json
+++ b/test/resources/transformed/variations/estates-personal-rep-transform-after-org.json
@@ -9,7 +9,7 @@
           "identification":{
             "utr":"newUtr"
           },
-          "entityStart":"1998-02-12"
+          "entityStart":"2011-11-21"
         }
       }
     }

--- a/test/resources/transformed/variations/valid-get-estate-response-transformed-with-amend-personal-rep.json
+++ b/test/resources/transformed/variations/valid-get-estate-response-transformed-with-amend-personal-rep.json
@@ -39,7 +39,7 @@
             }
           },
           "phoneNumber":"newPhone",
-          "entityStart":"2017-02-28",
+          "entityStart":"2020-02-10",
           "name":{
             "firstName":"newFirstName",
             "middleName":"newMiddleName",

--- a/test/uk/gov/hmrc/estates/transformers/variations/AddAmendBusinessPersonalRepTransformSpec.scala
+++ b/test/uk/gov/hmrc/estates/transformers/variations/AddAmendBusinessPersonalRepTransformSpec.scala
@@ -36,7 +36,7 @@ class AddAmendBusinessPersonalRepTransformSpec extends FreeSpec with MustMatcher
         phoneNumber = "newPhone",
         email = Some("newEmail"),
         identification = IdentificationOrgType(Some("newUtr"), None),
-        LocalDate.now,
+        LocalDate.of(2011, 11, 21),
         None
       )
       val transformer = AddAmendBusinessPersonalRepTransform(newPersonalRep)

--- a/test/uk/gov/hmrc/estates/transformers/variations/AddAmendIndividualPersonalRepTransformSpec.scala
+++ b/test/uk/gov/hmrc/estates/transformers/variations/AddAmendIndividualPersonalRepTransformSpec.scala
@@ -36,7 +36,7 @@ class AddAmendIndividualPersonalRepTransformSpec extends FreeSpec with MustMatch
         phoneNumber = "newPhone",
         email = Some("newEmail"),
         identification = IdentificationType(Some("newNino"), None, None),
-        entityStart = LocalDate.now,
+        entityStart = LocalDate.parse("2012-03-14"),
         entityEnd = None
       )
       val transformer = AddAmendIndividualPersonalRepTransform(newTrusteeInfo)


### PR DESCRIPTION
Amend sends the date anyway, and add needs to use the date sent, as it's new.