### PR TITLE
Bug fix: Removing UTR or NINO

### DIFF
--- a/test/resources/mdtp/valid-estate-registration-05-with-per-rep-org-utr.json
+++ b/test/resources/mdtp/valid-estate-registration-05-with-per-rep-org-utr.json
@@ -1,0 +1,51 @@
+ {
+  "correspondence": {
+    "abroadIndicator": false,
+    "name": "RLlVnX(G/e&kvM(9VmPI8tj,jOW8mlm7yXVcwUR1G4aDkuDI",
+    "address": {
+      "line1": "cf9-aI8biB1qszA,CWPs9yb0imNX",
+      "line2": "Y5&hb.TFmIepcR8f9c..",
+      "postCode": "Fu1a5JY",
+      "country": "GB"
+    },
+    "phoneNumber": "3786591082191 3"
+  },
+  "declaration": {
+    "name": {
+      "firstName": "ngQCJFaEXNCS'FQ4/8pnnQZ9),'vvj",
+      "lastName": "x3GY1&K"
+    },
+    "address": {
+      "line1": ".'D'2t-DpwOzS0k)a",
+      "line2": "cjedX5a)YvI",
+      "postCode": "M1g4Xt",
+      "country": "GB"
+    }
+  },
+  "estate": {
+    "entities": {
+      "deceased": {
+        "name": {
+          "firstName": "lni3DHd-X",
+          "lastName": ",Cecxov,,OrDtgF/ieEiNhOZF-qeb,k"
+        },
+        "dateOfDeath": "1561-05-29"
+      },
+      "personalRepresentative": {
+        "estatePerRepOrg": {
+          "orgName": "-NQSp(ji9eeTJP98.OICk4",
+          "phoneNumber": "30152694576 240953",
+          "identification": {
+            "utr": "1234567890",
+            "address": {
+              "line1": "yjBiNzs1JuvYIv886.ZLxeODG2g1",
+              "line2": "7'7'&p&,t5NcZE0vXDkk(eWj",
+              "country": "CU"
+            }
+          }
+        }
+      }
+    },
+    "periodTaxDues": "04"
+  }
+}

--- a/test/resources/transformed/declared/declaration-transform-personal-rep-ind-address-removed.json
+++ b/test/resources/transformed/declared/declaration-transform-personal-rep-ind-address-removed.json
@@ -1,0 +1,24 @@
+{
+  "correspondence": {
+    "address": {
+      "line1": "Line 1",
+      "line2": "Line 2",
+      "postCode": "NE981ZZ",
+      "country": "GB"
+    },
+    "phoneNumber": "078888888",
+    "name": "Estate of Personal Rep",
+    "abroadIndicator": false
+  },
+  "estate": {
+    "entities": {
+      "personalRepresentative": {
+        "estatePerRepInd": {
+          "identification": {
+            "nino": "JP121212A"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/resources/transformed/declared/declaration-transform-personal-rep-org-address-removed.json
+++ b/test/resources/transformed/declared/declaration-transform-personal-rep-org-address-removed.json
@@ -1,0 +1,25 @@
+{
+  "correspondence": {
+    "address": {
+      "line3": "line3",
+      "country": "Country",
+      "line1": "line1",
+      "line4": "line4",
+      "line2": "line2"
+    },
+    "phoneNumber": "078888888",
+    "name": "Estate of Personal Rep",
+    "abroadIndicator": true
+  },
+  "estate": {
+    "entities": {
+      "personalRepresentative": {
+        "estatePerRepOrg": {
+          "identification": {
+            "utr": "1234567890"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/resources/transformed/valid-estate-registration-01-personal-rep-org-transformed-without-utr.json
+++ b/test/resources/transformed/valid-estate-registration-01-personal-rep-org-transformed-without-utr.json
@@ -1,0 +1,54 @@
+{
+  "correspondence": {
+    "abroadIndicator": false,
+    "name": "RLlVnX(G/e&kvM(9VmPI8tj,jOW8mlm7yXVcwUR1G4aDkuDI",
+    "address": {
+      "line1": "cf9-aI8biB1qszA,CWPs9yb0imNX",
+      "line2": "Y5&hb.TFmIepcR8f9c..",
+      "postCode": "Fu1a5JY",
+      "country": "GB"
+    },
+    "phoneNumber": "3786591082191 3"
+  },
+  "declaration": {
+    "name": {
+      "firstName": "ngQCJFaEXNCS'FQ4/8pnnQZ9),'vvj",
+      "lastName": "x3GY1&K"
+    },
+    "address": {
+      "line1": ".'D'2t-DpwOzS0k)a",
+      "line2": "cjedX5a)YvI",
+      "postCode": "M1g4Xt",
+      "country": "GB"
+    }
+  },
+  "estate": {
+    "entities": {
+      "deceased": {
+        "name": {
+          "firstName": "lni3DHd-X",
+          "lastName": ",Cecxov,,OrDtgF/ieEiNhOZF-qeb,k"
+        },
+        "dateOfDeath": "1561-05-29"
+      },
+      "personalRepresentative": {
+        "estatePerRepOrg": {
+          "orgName": "Lovely Organisation",
+          "phoneNumber": "078888888",
+          "email": "testy@xyz.org",
+          "identification": {
+            "address": {
+              "line1": "line1",
+              "line2": "line2",
+              "line3": "line3",
+              "line4": "line4",
+              "postCode": "postCode",
+              "country": "Country"
+            }
+          }
+        }
+      }
+    },
+    "periodTaxDues": "04"
+  }
+}


### PR DESCRIPTION
- Correctly only remove UTR or NINO if it's present on final transformed
document, not in the current transform applied. Due to multiple
transforms overriding each other and conflicting. Final transformed
document is source of truth.